### PR TITLE
chore: followup to 27558d7, fix repository URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # `@neoncitylights/stdlib`
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![GitHub deployments](https://img.shields.io/github/deployments/neoncitylights/stdlib/github-pages?label=deploy)](https://github.com/neoncitylights/stdlib/deployments/activity_log?environment=github-pages)
-[![Node.js workflow](https://github.com/neoncitylights/stdlib/actions/workflows/main.yml/badge.svg)](https://github.com/neoncitylights/stdlib/actions/workflows/main.yml)
+[![Node.js workflow](https://github.com/neoncitylights/ts-stdlib/actions/workflows/main.yml/badge.svg)](https://github.com/neoncitylights/ts-stdlib/actions/workflows/main.yml)
 
 This package's name is currently a WIP. Currently contains a somewhat random assortion of utilities in TypeScript.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@neoncitylights/stdlib",
+	"name": "@neoncitylights/ts-stdlib",
 	"version": "0.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@neoncitylights/stdlib",
+			"name": "@neoncitylights/ts-stdlib",
 			"version": "0.0.0",
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@neoncitylights/stdlib",
+	"name": "@neoncitylights/ts-stdlib",
 	"version": "0.0.0",
 	"description": "A TypeScript library with a (somewhat) random assortion of utilities ",
 	"license": "MIT",
@@ -10,10 +10,10 @@
 	"keywords": [
 		"typescript"
 	],
-	"bugs": "https://github.com/neoncitylights/stdlib/issues",
+	"bugs": "https://github.com/neoncitylights/ts-stdlib/issues",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/neoncitylights/stdlib.git"
+		"url": "git+https://github.com/neoncitylights/ts-stdlib.git"
 	},
 	"funding": {
 		"type": "individual",


### PR DESCRIPTION
 - remove old deployment badge from README.md