### PR TITLE
ci: add job for quickly checking if package is publishable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+  pkg-is-publishable:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm ci
+      - name: Check if publishable
+        run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   # docs:
   #   runs-on: ubuntu-latest
   #   if: ${{ github.event_name == 'push' }}
@@ -92,8 +111,9 @@ jobs:
     needs:
       - build
       - lint
-      #- test
+      - test
       # - docs
+      - pkg-is-publishable
     steps:
       - name: ✅ CI succeeded
         run: exit 0
@@ -104,7 +124,8 @@ jobs:
     needs:
       - build
       - lint
-      #- test
+      - test
+      - pkg-is-publishable
     steps:
       - name: ✅ CI succeeded
         run: exit 0


### PR DESCRIPTION
 - also make `test` job a requirement for `ci-success` + `ci-success-pr` jobs