### PR TITLE
fix: followup to eecf34e, fix random gen for u8/u16/u32

### DIFF
--- a/src/math/random.ts
+++ b/src/math/random.ts
@@ -202,20 +202,20 @@ export function getRandI32(): number {
 /**
  * Generates a number within the inclusive range of an unsigned 8-bit integer
  */
-export function getRandomU8(): number {
-	return getRandInt(consts.I8_MIN, consts.I8_MAX);
+export function getRandU8(): number {
+	return getRandInt(consts.U8_MIN, consts.U8_MAX);
 }
 
 /**
  * Generates a number within the inclusive range of a 16-bit unsigned integer
  */
-export function getRandomU16(): number {
-	return getRandInt(consts.I16_MIN, consts.I16_MAX);
+export function getRandU16(): number {
+	return getRandInt(consts.U16_MIN, consts.U16_MAX);
 }
 
 /**
  * Generates a number within the inclusive range of a 32-bit unsigned integer
  */
-export function getRandomU32(): number {
-	return getRandInt(consts.I32_MIN, consts.I32_MAX);
+export function getRandU32(): number {
+	return getRandInt(consts.U32_MIN, consts.U32_MAX);
 }

--- a/tests/math/random.test.ts
+++ b/tests/math/random.test.ts
@@ -7,6 +7,12 @@ import {
 	getRandBool,
 	getRandItem,
 	getRandString,
+	getRandU8,
+	getRandU16,
+	getRandU32,
+	getRandI8,
+	getRandI16,
+	getRandI32,
 } from '../../src/math';
 
 describe('getRandString()', () => {
@@ -44,3 +50,53 @@ describe('getRandArrayF32()', () => {
 	});
 });
 
+describe('getRandI8()', () => {
+	test('randomly generates between -128 and 127', () => {
+		const random = getRandI8();
+		expectToBeBetweenInclusive(random, -128, 127);
+	})
+})
+
+describe('getRandI16()', () => {
+	test('randomly generates between -32768 and 32767', () => {
+		const random = getRandI16();
+		expectToBeBetweenInclusive(random, -32768, 32767);
+	})
+})
+
+describe('getRandI32()', () => {
+	test('randomly generates between -2147483648 and 2147483647', () => {
+		const random = getRandI32();
+		expectToBeBetweenInclusive(random, -2147483648, 2147483647);
+	})
+})
+
+describe('getRandU8()', () => {
+	test('randomly generates between 0 and 255', () => {
+		const random = getRandU8();
+		expectToBeBetweenInclusive(random, 0, 255);
+	})
+})
+
+describe('getRandU16()', () => {
+	test('randomly generates between 0 and 65535', () => {
+		const random = getRandU16();
+		expectToBeBetweenInclusive(random, 0, 65535);
+	})
+})
+
+describe('getRandU32()', () => {
+	test('randomly generates between 0 and 4294967295', () => {
+		const random = getRandU32();
+		expectToBeBetweenInclusive(random, 0, 4294967295);
+	})
+})
+
+function expectToBeBetweenInclusive(
+	value: number,
+	min: number,
+	max: number,
+) {
+	expect(value).toBeGreaterThanOrEqual(min);
+	expect(value).toBeLessThanOrEqual(max);
+}


### PR DESCRIPTION
 - api: rename getRandomU8/getRandomU16/getRandomU32 to getRandU8/getRandU16/getRandU32 respectively
 - fix: use unsigned constants instead of signed constants for all three methods
 - tests: add unit tests/regression tests